### PR TITLE
Make the "main" of package.json a string instead of array

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "keywords": [
     "hawtio"
   ],
-  "main": [
-    "dist/hawtio-utilities.js"
-  ],
+  "main": "dist/hawtio-utilities.js",
   "ignore": [
     ".bowerrc",
     ".jshintrc",


### PR DESCRIPTION
When using hawtio 2 modules with pure npm (no bower), this module cannot be npm install-ed because it does not conform to the spec.  The main of package.json is a string only with npm, unlike bower which can be an array.

In building our hawtio 1.x application, we ditched bower instead of pure npm with browserify.  We are doing a hawtio2 port and ran into this.  Please accept this PR!

I found a reference to a similar problem here: https://github.com/npm/npm/issues/9917
